### PR TITLE
Additional function in http tests for checking headers...

### DIFF
--- a/lib/ntf/http.js
+++ b/lib/ntf/http.js
@@ -14,6 +14,14 @@ var asserts = exports.asserts = {
       (contains instanceof RegExp ? res.data.match(contains) : res.data.indexOf(contains) >= 0),
       'Content contains "' + contains + '"')
   },
+  header: function(res, name, value) {
+	name = name.toLowerCase();
+	this.ok(typeof(res) === 'object' &&
+			typeof(res.headers) === 'object' &&
+			res.headers[name] &&
+			res.headers[name] == value,
+		'Header[' + name + '] is "' + value + '"')
+  },
   json: function(res, data) {
     var json = undefined
     try {


### PR DESCRIPTION
I was using the network test framework to check URL redirects, and this was essential for that set of use cases where I was checking essentially empty responses for correct headers.
